### PR TITLE
mo permissions and intermediate layer cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ADD https://raw.githubusercontent.com/tests-always-included/mo/master/mo /usr/bin/
 RUN chmod a+rx /usr/bin/mo
 
-RUN apt-get update && apt-get install gosu && apt-get -y upgrade
-RUN apt-get clean
-RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN apt-get update && \
+    apt-get install -y gosu && \
+    apt-get -y upgrade && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 #add this for mustache templates in config files
 ADD https://raw.githubusercontent.com/tests-always-included/mo/master/mo /usr/bin/
-RUN chmod +x /usr/bin/mo
+RUN chmod a+rx /usr/bin/mo
 
 RUN apt-get update && apt-get install gosu && apt-get -y upgrade
 RUN apt-get clean

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,6 @@ RUN chmod a+rx /usr/bin/mo
 
 RUN apt-get update && \
     apt-get install -y gosu && \
-    apt-get -y upgrade && \
+    apt-get upgrade -y && \
+    apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
This gives all users permission to use `mo` (which `root` only had privileges for before) and cleans up some of the docker organization to minimize the size of intermediate layers.

I'm a little nervous about updating the base image since it hasn't been rebuilt in two years. @bfs would know best.

@bfs @ndigati This repo is not inside the Factual organization, and I think it should be.